### PR TITLE
piku-bootstrap script for provisioning a server with piku.py

### DIFF
--- a/piku-bootstrap
+++ b/piku-bootstrap
@@ -49,6 +49,13 @@ main() {
 ---
 - hosts: all
   user: root
+  gather_facts: no
+  pre_tasks:
+    - name: 'Install python2 required by Ansible'
+      raw: apt-get update && apt-get -y install python python-pip python-setuptools
+
+- hosts: all
+  user: root
   tasks:
     - name: Add piku user
       user:

--- a/piku-bootstrap
+++ b/piku-bootstrap
@@ -44,19 +44,27 @@ main() {
     echo "setup git, and install the piku script there."
     echo "Requires root on HOSTNAME."
   else
-    echo "Bootstrapping piku onto $1"
+    host="$1"; shift
+    # check for raspberry pi user flag
+    if [ "$1" = "--pi" ]; then PIKU_SSH=pi; shift; else PIKU_SSH=root; fi;
+    echo "Bootstrapping piku onto ${host}"
     # TODO: use pyenv + virtualenv on remote instead and install exact versions
-    ansible-playbook -i "$1", /dev/stdin << EOF
+    PIKU_SSH="${PIKU_SSH}" PYTHONWARNINGS="ignore" ansible-playbook -i "${host}", "$@" /dev/stdin << EOF
 ---
 - hosts: all
-  user: root
+  become: yes
   gather_facts: no
+  vars:
+    default_user: "{{ lookup('env', 'PIKU_SSH') }}"
   pre_tasks:
-    - name: 'Install python2 required by Ansible'
-      raw: apt-get update && apt-get -y install python python-pip python-setuptools
+    - name: Set default SSH user
+      set_fact: ansible_ssh_user="{{default_user}}"
+
+    - name: Install python2 required by Ansible
+      raw: "( /usr/bin/python --version 2>&1 | grep -c 'Python' > /dev/null ) || apt-get update && apt-get -y install python"
 
 - hosts: all
-  user: root
+  become: yes
   tasks:
     - name: Add piku user
       user:
@@ -67,7 +75,7 @@ main() {
 
     - name: Install Debian Packages
       apt:
-        pkg: ['bc', 'git', 'build-essential', 'libpcre3-dev', 'zlib1g-dev', 'python', 'python3', 'python3-pip', 'python3-dev', 'python3-setuptools', 'nginx', 'incron']
+        pkg: ['bc', 'git', 'build-essential', 'libpcre3-dev', 'zlib1g-dev', 'python', 'python3', 'python3-pip', 'python3-dev', 'python-pip', 'python-setuptools', 'python3-setuptools', 'nginx', 'incron', 'acl']
         #, 'python-dev', 'python3', 'python3-virtualenv', 'python3-pip']
         update_cache: true
         state: present
@@ -120,7 +128,6 @@ main() {
         state: directory
 
 - hosts: all
-  user: root
   become: yes
   become_user: piku
   tasks:
@@ -163,7 +170,7 @@ main() {
         creates: ~/.ssh/authorized_keys
 
 - hosts: all
-  user: root
+  become: yes
   tasks:
     - name: Start uwsgi service
       service:
@@ -228,4 +235,4 @@ install_virtualenv() {
           || bail_install;
 }
 
-main "$1"
+main "$@"

--- a/piku-bootstrap
+++ b/piku-bootstrap
@@ -10,6 +10,14 @@ VENV="${PBD}/virtualenv"
 VIRTUALENV_VERSION="16.0.0"
 
 main() {
+  # print a message if this is a first time run
+  if [ ! -d "${PBD}" ]; then
+    echo "piku-bootstrap - welcome!"
+    echo "Looks like this is your first time running this."
+    echo "This script will self-install dependencies into ${PBD} now."
+    echo
+  fi
+
   # ensure we have a dir
   mkdir -p "${PBD}"
 
@@ -31,6 +39,9 @@ main() {
   if [ "$1" = "" ]
   then
     echo "`basename $0` HOSTNAME"
+    echo "This will create a user 'piku' on the machine HOSTNAME"
+    echo "setup git, and install the piku script there."
+    echo "Requires root on HOSTNAME."
   else
     echo "Bootstrapping piku onto $1"
     ansible-playbook -i "$1", /dev/stdin << EOF

--- a/piku-bootstrap
+++ b/piku-bootstrap
@@ -8,6 +8,7 @@
 PBD=${PIKU_BOOTSTRAP_DIR:-~/.piku-bootstrap}
 VENV="${PBD}/virtualenv"
 VIRTUALENV_VERSION="16.0.0"
+LOG="${PBD}/install.log"
 
 main() {
   # print a message if this is a first time run
@@ -22,7 +23,7 @@ main() {
   mkdir -p "${PBD}"
 
   if [ ! -d "$VENV" ]; then
-    echo "Virtualenv setup not found. Installing it into ${PBD}."
+    echo " #> Virtualenv setup not found. Installing it into ${PBD}."
     ensure_virtualenv
   fi
 
@@ -32,8 +33,8 @@ main() {
   # ensure ansible
   if [ "`command -v ansible-playbook`" = "" ]
   then
-    echo "ansible-playbook binary not found. Installing it into ${PBD}."
-    pip install -q "ansible==2.7.10"
+    echo " #> ansible-playbook binary not found. Installing it into ${PBD}."
+    pip install -q "ansible==2.7.10" >"${LOG}" 2>&1
   fi
 
   if [ "$1" = "" ]
@@ -199,7 +200,8 @@ EOF
 }
 
 bail_install() {
-    error "Self-installation failed."
+    echo " #> Self-installation failed."
+    echo " #> Check ${LOG} for details."
     exit 1;
 }
 
@@ -208,21 +210,21 @@ ensure_virtualenv() {
   [ -d "${PBD}/virtualenv" ] || (\
       cd "${PBD}"
       [ -f "./.virtualenv-source/virtualenv.py" ] || install_virtualenv;
-      echo "Setting up the virtual environment." && \
-      ./.virtualenv-source/virtualenv.py -p `which python` "${PBD}/virtualenv" || exit 1)
+      echo " #> Setting up the virtual environment." && \
+      ./.virtualenv-source/virtualenv.py -q "${PBD}/virtualenv" || bail_install)
       rm -rf ./.virtualenv-source
 }
 
 install_virtualenv() {
   VIRTUALENV_URL="https://pypi.io/packages/source/v/virtualenv/virtualenv-${VIRTUALENV_VERSION}.tar.gz"
-  echo "Downloading & installing Virtualenv."
+  echo " #> Downloading & installing Virtualenv."
   rm -rf "./.virtualenv-source"
   mkdir -p "./.virtualenv-source"
-  [ -f "./virtualenv.tar.gz" ] || curl -f -L -o "./virtualenv.tar.gz" "${VIRTUALENV_URL}" || bail_install
+  [ -f "./virtualenv.tar.gz" ] || curl -s -f -L -o "./virtualenv.tar.gz" "${VIRTUALENV_URL}" || bail_install
   tar -zxf "./virtualenv.tar.gz" -C "./.virtualenv-source/" --strip-components=1 && \
   [ -d "./.virtualenv-source" ] && (\
           cd "./.virtualenv-source" && \
-          /usr/bin/env python setup.py build ) \
+          /usr/bin/env python setup.py build > ${LOG} 2>&1 ) \
           || bail_install;
 }
 

--- a/piku-bootstrap
+++ b/piku-bootstrap
@@ -116,6 +116,14 @@ main() {
         state: started
       when: packages_installed is changed
 
+    - name: Create piku ansible tmp dir
+      file:
+        path: ~piku/.ansible/tmp
+        mode: 0700
+        owner: piku
+        group: www-data
+        state: directory
+
 - hosts: all
   user: root
   become: yes

--- a/piku-bootstrap
+++ b/piku-bootstrap
@@ -13,9 +13,10 @@ LOG="${PBD}/install.log"
 main() {
   # print a message if this is a first time run
   if [ ! -d "${PBD}" ]; then
-    echo "piku-bootstrap - welcome!"
-    echo "Looks like this is your first time running this."
+    echo "Looks like this is your first time running piku-bootstrap."
     echo "This script will self-install dependencies into ${PBD} now."
+    echo "Hit enter to continue or ctrl-C to abort."
+    read discarded
     echo
   fi
 
@@ -39,10 +40,18 @@ main() {
 
   if [ "$1" = "" ]
   then
-    echo "`basename $0` HOSTNAME"
-    echo "This will create a user 'piku' on the machine HOSTNAME"
-    echo "setup git, and install the piku script there."
-    echo "Requires root on HOSTNAME."
+    echo
+    echo "Usage: `basename $0` HOST [--pi] [...YOUR_ANSIBLE_ARGS...]"
+    echo
+    echo " HOST\tCreates a user 'piku' on the machine 'HOST',"
+    echo "\tinstalls git, and install the piku script there."
+    echo
+    echo " --pi\tShortcut to SSH in as the user 'pi'."
+    echo "\tUse \`ssh-copy-id pi@HOSTNAME\` to upload SSH key first."
+    echo
+    echo "\tRequires root/sudo on HOSTNAME (--pi implies sudo)."
+    echo "\tRequires HOSTNAME to be a Debian based distribution."
+    echo
   else
     host="$1"; shift
     # check for raspberry pi user flag

--- a/piku-bootstrap
+++ b/piku-bootstrap
@@ -110,12 +110,6 @@ main() {
         mode: 0600
       when: packages_installed is changed
 
-    - name: Start uwsgi service
-      service:
-        name: uwsgi-piku
-        state: started
-      when: packages_installed is changed
-
     - name: Create piku ansible tmp dir
       file:
         path: ~piku/.ansible/tmp
@@ -166,6 +160,39 @@ main() {
       shell: python3 ~/piku.py setup:ssh /tmp/id_rsa.pub
       args:
         creates: ~/.ssh/authorized_keys
+
+- hosts: all
+  user: root
+  tasks:
+    - name: Start uwsgi service
+      service:
+        name: uwsgi-piku
+        state: started
+
+    - name: Get nginx default config
+      get_url:
+        url: https://raw.githubusercontent.com/rcarmo/piku/master/nginx.default.dist
+        dest: /etc/nginx/sites-available/default
+        force: yes
+      register: nginx_config_installed
+
+    - name: Restart nginx service
+      service:
+        name: nginx
+        state: restarted
+      when: nginx_config_installed is changed
+
+    - name: Get incron config
+      get_url:
+        url: https://raw.githubusercontent.com/rcarmo/piku/master/incron.dist
+        dest: /etc/incron.d/piku
+      register: incron_config_installed
+
+    - name: Restart incron service
+      service:
+        name: incron
+        state: restarted
+      when: incron_config_installed is changed
 
 EOF
   fi

--- a/piku-bootstrap
+++ b/piku-bootstrap
@@ -44,6 +44,7 @@ main() {
     echo "Requires root on HOSTNAME."
   else
     echo "Bootstrapping piku onto $1"
+    # TODO: use pyenv + virtualenv on remote instead and install exact versions
     ansible-playbook -i "$1", /dev/stdin << EOF
 ---
 - hosts: all
@@ -56,27 +57,64 @@ main() {
         comment: PaaS access
         group: www-data
 
-    #- name: Add current user's SSH key
-    #  authorized_key:
-    #    user: piku
-    #    state: present
-    #    key: "{{ lookup('file', '~/.ssh/id_rsa.pub') }}"
-    #    # key_options: "command="FINGERPRINT=85:29:07:cb:de:ad:be:ef:42:65:00:c8:d2:6b:9e:ff NAME=default /home/piku/piku.py $SSH_ORIGINAL_COMMAND",no-agent-forwarding,no-user-rc,no-X11-forwarding,no-port-forwarding"
-
     - name: Install Debian Packages
       apt:
         pkg: ['git', 'build-essential', 'libpcre3-dev', 'zlib1g-dev', 'python', 'python3', 'python3-pip', 'python3-dev']  #, 'python-dev', 'python3', 'python3-virtualenv', 'python3-pip']
         update_cache: true
         state: present
-    
+
     - name: Install Python packages
       pip:
         executable: pip3
-        name: ['click', 'virtualenv']
+        name: ['click==7.0', 'virtualenv==15.1.0', 'uwsgi==2.0.15']
+      register: packages_installed
+
+    - shell: which uwsgi
+      register: uwsgi_location
+      when: packages_installed is changed
+
+    - name: Create uwsi symlink
+      file:
+        src: "{{uwsgi_location.stdout}}"
+        dest: /usr/local/bin/uwsgi-piku
+        owner: root
+        group: root
+        state: link
+      when: packages_installed is changed
+
+    - name: Install uwsgi dist script
+      get_url:
+        url: https://raw.githubusercontent.com/rcarmo/piku/master/uwsgi-piku.dist
+        dest: /etc/init.d/uwsgi-piku
+        mode: 0700
+      when: packages_installed is changed
+
+    - name: Setup uwsgi dist script
+      shell: update-rc.d uwsgi-piku defaults
+      args:
+        creates: /etc/rc2.d/S01uwsgi-piku
+      when: packages_installed is changed
+
+    - name: Install uwsgi systemd script
+      get_url:
+        url: https://raw.githubusercontent.com/rcarmo/piku/master/uwsgi-piku.service
+        dest: /etc/systemd/system/uwsgi-piku.service
+        mode: 0600
+      when: packages_installed is changed
+
+    - name: Start uwsgi service
+      service:
+        name: uwsgi-piku
+        state: started
+      when: packages_installed is changed
 
 - hosts: all
-  user: piku
+  user: root
+  become: yes
+  become_user: piku
   tasks:
+    ### TODO: use pyenv like this instead
+
     #- name: Download pyenv installer
     #  get_url:
     #    url: https://pyenv.run
@@ -109,7 +147,9 @@ main() {
       copy: src=~/.ssh/id_rsa.pub dest=/tmp/id_rsa.pub
 
     - name: Ask piku to use SSH key
-      shell: python3 piku.py setup:ssh /tmp/id_rsa.pub
+      shell: python3 ~/piku.py setup:ssh /tmp/id_rsa.pub
+      args:
+        creates: ~/.ssh/authorized_keys
 
 EOF
   fi
@@ -121,6 +161,7 @@ bail_install() {
 }
 
 ensure_virtualenv() {
+  # TODO: use local virtualenv instead if `command -v virtualenv` succeeds
   [ -d "${PBD}/virtualenv" ] || (\
       [ -f "./.virtualenv-source/virtualenv.py" ] || install_virtualenv;
       echo "Setting up the virtual environment." && \

--- a/piku-bootstrap
+++ b/piku-bootstrap
@@ -56,32 +56,60 @@ main() {
         comment: PaaS access
         group: www-data
 
+    #- name: Add current user's SSH key
+    #  authorized_key:
+    #    user: piku
+    #    state: present
+    #    key: "{{ lookup('file', '~/.ssh/id_rsa.pub') }}"
+    #    # key_options: "command="FINGERPRINT=85:29:07:cb:de:ad:be:ef:42:65:00:c8:d2:6b:9e:ff NAME=default /home/piku/piku.py $SSH_ORIGINAL_COMMAND",no-agent-forwarding,no-user-rc,no-X11-forwarding,no-port-forwarding"
+
+    - name: Install Debian Packages
+      apt:
+        pkg: ['git', 'build-essential', 'libpcre3-dev', 'zlib1g-dev', 'python', 'python3', 'python3-pip', 'python3-dev']  #, 'python-dev', 'python3', 'python3-virtualenv', 'python3-pip']
+        update_cache: true
+        state: present
+    
+    - name: Install Python packages
+      pip:
+        executable: pip3
+        name: ['click', 'virtualenv']
+
+- hosts: all
+  user: piku
+  tasks:
+    #- name: Download pyenv installer
+    #  get_url:
+    #    url: https://pyenv.run
+    #    dest: ~/pyenv-installer
+    #    mode: 0755
+
+    #- name: Run pyenv installer
+    #  shell:
+    #    argv: ~/pyenv-installer
+    #    creates: ~/.pyenv
+
+    #- name: Install python3
+    #  shell: ~/.pyenv/bin/pyenv install 3.6.8
+
+    #- name: Use python3
+    #  shell: ~/.pyenv/bin/pyenv local 3.6.8
+
     - name: Fetch piku.py script
       get_url:
         url: https://raw.githubusercontent.com/rcarmo/piku/master/piku.py
         dest: ~/piku.py
         mode: 0700
 
-    - name: Add current user's SSH key
-      authorized_key:
-        user: piku
-        state: present
-        key: "{{ lookup('file', '~/.ssh/id_rsa.pub') }}"
+    - name: Run piku setup
+      shell: python3 ~/piku.py setup
+      args:
+        creates: ~/.piku
 
-    - name: Install Debian Packages
-      apt: pkg={{item}} state=installed
-      with_items:
-        - git
-        - python3
-        - build-essential
-        - python-dev
-        - libpcre3-dev
+    - name: Copy up my SSH key for piku
+      copy: src=~/.ssh/id_rsa.pub dest=/tmp/id_rsa.pub
 
-#- hosts: all
-#  user: piku
-#  tasks:
-#    - name: Install pyenv
-#      shell: curl https://pyenv.run | bash
+    - name: Ask piku to use SSH key
+      shell: python3 piku.py setup:ssh /tmp/id_rsa.pub
 
 EOF
   fi
@@ -93,22 +121,22 @@ bail_install() {
 }
 
 ensure_virtualenv() {
-  [ -f "${PBD}/virtualenv-source/virtualenv.py" ] || install_virtualenv;
   [ -d "${PBD}/virtualenv" ] || (\
+      [ -f "./.virtualenv-source/virtualenv.py" ] || install_virtualenv;
       echo "Setting up the virtual environment." && \
-      ${PBD}/virtualenv-source/virtualenv.py -p python "${PBD}/virtualenv" || exit 1)
+      ./.virtualenv-source/virtualenv.py -p `which python` "${PBD}/virtualenv" || exit 1)
+      rm -rf ./.virtualenv-source
 }
 
 install_virtualenv() {
   VIRTUALENV_URL="https://pypi.io/packages/source/v/virtualenv/virtualenv-${VIRTUALENV_VERSION}.tar.gz"
   echo "Downloading & installing Virtualenv."
-  rm -rf "${PBD}/virtualenv-source"
-  mkdir -p "${PBD}/virtualenv-source"
-  [ -f "${PBD}/virtualenv.tar.gz" ] || curl -f -L -o "${PBD}/virtualenv.tar.gz" "${VIRTUALENV_URL}" || bail_install
-  tar -zxf $PBD/virtualenv.tar.gz -C "${PBD}/virtualenv-source/" --strip-components=1 && \
-  # mv "${PBD}/virtualenv-source/virtualenv-*/*" "${PBD}/virtualenv-source"
-  [ -d "${PBD}/virtualenv-source" ] && (\
-          cd "${PBD}/virtualenv-source" && \
+  rm -rf "./.virtualenv-source"
+  mkdir -p "./.virtualenv-source"
+  [ -f "./virtualenv.tar.gz" ] || curl -f -L -o "./virtualenv.tar.gz" "${VIRTUALENV_URL}" || bail_install
+  tar -zxf "./virtualenv.tar.gz" -C "./.virtualenv-source/" --strip-components=1 && \
+  [ -d "./.virtualenv-source" ] && (\
+          cd "./.virtualenv-source" && \
           /usr/bin/env python setup.py build ) \
           || bail_install;
 }

--- a/piku-bootstrap
+++ b/piku-bootstrap
@@ -66,14 +66,15 @@ main() {
 
     - name: Install Debian Packages
       apt:
-        pkg: ['git', 'build-essential', 'libpcre3-dev', 'zlib1g-dev', 'python', 'python3', 'python3-pip', 'python3-dev']  #, 'python-dev', 'python3', 'python3-virtualenv', 'python3-pip']
+        pkg: ['bc', 'git', 'build-essential', 'libpcre3-dev', 'zlib1g-dev', 'python', 'python3', 'python3-pip', 'python3-dev', 'python3-setuptools', 'nginx', 'incron']
+        #, 'python-dev', 'python3', 'python3-virtualenv', 'python3-pip']
         update_cache: true
         state: present
 
     - name: Install Python packages
       pip:
         executable: pip3
-        name: ['click==7.0', 'virtualenv==15.1.0', 'uwsgi==2.0.15']
+        name: ['setuptools', 'click==7.0', 'virtualenv==15.1.0', 'uwsgi==2.0.15']
       register: packages_installed
 
     - shell: which uwsgi

--- a/piku-bootstrap
+++ b/piku-bootstrap
@@ -179,6 +179,7 @@ bail_install() {
 ensure_virtualenv() {
   # TODO: use local virtualenv instead if `command -v virtualenv` succeeds
   [ -d "${PBD}/virtualenv" ] || (\
+      cd "${PBD}"
       [ -f "./.virtualenv-source/virtualenv.py" ] || install_virtualenv;
       echo "Setting up the virtual environment." && \
       ./.virtualenv-source/virtualenv.py -p `which python` "${PBD}/virtualenv" || exit 1)

--- a/piku-bootstrap
+++ b/piku-bootstrap
@@ -1,0 +1,105 @@
+#!/bin/sh
+
+# Usage:
+# To bootstrap your machine called mybox.com with piku
+# 
+# ./piku-bootstrap mybox.com
+
+PBD=${PIKU_BOOTSTRAP_DIR:-~/.piku-bootstrap}
+VENV="${PBD}/virtualenv"
+VIRTUALENV_VERSION="16.0.0"
+
+main() {
+  # ensure we have a dir
+  mkdir -p "${PBD}"
+
+  if [ ! -d "$VENV" ]; then
+    echo "Virtualenv setup not found. Installing it into ${PBD}."
+    ensure_virtualenv
+  fi
+
+  # get into virtualenv
+  . "$VENV/bin/activate"
+
+  # ensure ansible
+  if [ "`command -v ansible-playbook`" = "" ]
+  then
+    echo "ansible-playbook binary not found. Installing it into ${PBD}."
+    pip install -q "ansible==2.7.10"
+  fi
+
+  if [ "$1" = "" ]
+  then
+    echo "`basename $0` HOSTNAME"
+  else
+    echo "Bootstrapping piku onto $1"
+    ansible-playbook -i "$1", /dev/stdin << EOF
+---
+- hosts: all
+  user: root
+  tasks:
+    - name: Add piku user
+      user:
+        name: piku
+        password: !
+        comment: PaaS access
+        group: www-data
+
+    - name: Fetch piku.py script
+      get_url:
+        url: https://raw.githubusercontent.com/rcarmo/piku/master/piku.py
+        dest: ~/piku.py
+        mode: 0700
+
+    - name: Add current user's SSH key
+      authorized_key:
+        user: piku
+        state: present
+        key: "{{ lookup('file', '~/.ssh/id_rsa.pub') }}"
+
+    - name: Install Debian Packages
+      apt: pkg={{item}} state=installed
+      with_items:
+        - git
+        - python3
+        - build-essential
+        - python-dev
+        - libpcre3-dev
+
+#- hosts: all
+#  user: piku
+#  tasks:
+#    - name: Install pyenv
+#      shell: curl https://pyenv.run | bash
+
+EOF
+  fi
+}
+
+bail_install() {
+    error "Self-installation failed."
+    exit 1;
+}
+
+ensure_virtualenv() {
+  [ -f "${PBD}/virtualenv-source/virtualenv.py" ] || install_virtualenv;
+  [ -d "${PBD}/virtualenv" ] || (\
+      echo "Setting up the virtual environment." && \
+      ${PBD}/virtualenv-source/virtualenv.py -p python "${PBD}/virtualenv" || exit 1)
+}
+
+install_virtualenv() {
+  VIRTUALENV_URL="https://pypi.io/packages/source/v/virtualenv/virtualenv-${VIRTUALENV_VERSION}.tar.gz"
+  echo "Downloading & installing Virtualenv."
+  rm -rf "${PBD}/virtualenv-source"
+  mkdir -p "${PBD}/virtualenv-source"
+  [ -f "${PBD}/virtualenv.tar.gz" ] || curl -f -L -o "${PBD}/virtualenv.tar.gz" "${VIRTUALENV_URL}" || bail_install
+  tar -zxf $PBD/virtualenv.tar.gz -C "${PBD}/virtualenv-source/" --strip-components=1 && \
+  # mv "${PBD}/virtualenv-source/virtualenv-*/*" "${PBD}/virtualenv-source"
+  [ -d "${PBD}/virtualenv-source" ] && (\
+          cd "${PBD}/virtualenv-source" && \
+          /usr/bin/env python setup.py build ) \
+          || bail_install;
+}
+
+main "$1"


### PR DESCRIPTION
Hi @rcarmo this PR adds a new script `piku-bootstrap` which is intended to be run from the user's own machine and provisions a freshly installed remote server with piku. It basically does what is written in INSTALL.md (thanks for the comprehensive guide).

```
curl https://raw.githubusercontent.com/chr15m/piku/piku-bootstrap/piku-bootstrap > piku-bootstrap
chmod 700 piku-bootstrap
./piku-bootstrap
... sets up venv etc. ...
./piku-bootstrap my-fresh-vps-box.net
```

How it works:

 * Uses whatever Python binary the user has lying around.
 * Sets up in `~/.piku-bootstrap` on their machine. [first run only]
 * Downloads & builds virtualenv source. [first run only]
 * Gets into virtualenv.
 * Installs ansible into virtualenv. [first run only]
 * Runs embedded ansible playbook to deploy piku to the server specified.

So far tested against a Digital Ocean VPS running Ubuntu 16.04.6 x64 and it works to deploy the Python example. Would be nice to see if this runs against a fresh Raspbian or Ubuntu on Raspberry Pi.