### PR TITLE
Alias NGINX_HTTPS_ONLY and add doc.

### DIFF
--- a/docs/ENV.md
+++ b/docs/ENV.md
@@ -27,3 +27,4 @@ You can configure deployment settings by placing special variables in an `ENV` f
 * `NGINX_SERVER_NAME`: set the virtual host name associated with your app
 * `NGINX_CLOUDFLARE_ACL` (boolean): activate an ACL allowing access only from Cloudflare IPs
 * `NGINX_STATIC_PATHS`: set an array of `/url:path` values
+* `NGINX_HTTPS_ONLY`: tell nginx to auto-redirect non-SSL traffic to SSL site

--- a/piku.py
+++ b/piku.py
@@ -558,7 +558,7 @@ def spawn_app(app, deltas={}):
                     env['INTERNAL_NGINX_STATIC_MAPPINGS'] = ''
 
             echo("-----> nginx will map app '{}' to hostname '{}'".format(app, env['NGINX_SERVER_NAME']))
-            if('HTTPS_ONLY' in env):
+            if('NGINX_HTTPS_ONLY' in env) or ('HTTPS_ONLY' in env):
                 buffer = expandvars(NGINX_HTTPS_ONLY_TEMPLATE, env)
                 echo("-----> nginx will redirect all requests to hostname '{}' to HTTPS".format(env['NGINX_SERVER_NAME']))
             else:


### PR DESCRIPTION
This patch allows for more consistent naming of this nginx-controlling parameter (`HTTPS_ONLY` -> `NGINX_HTTPS_ONLY`) but aliases it so as not to break @rcarmo's existing deployments. Also documents the flag.