### PR TITLE
User can specify `release` command in Procfile.

### DIFF
--- a/piku.py
+++ b/piku.py
@@ -320,6 +320,9 @@ def do_deploy(app, deltas={}):
             makedirs(log_path)
         workers = parse_procfile(procfile)
         if workers and len(workers):
+            if "release" in workers:
+                echo("-----> Releasing", fg='green')
+                call(workers["release"], cwd=app_path, env=env, shell=True)
             if exists(join(app_path, 'requirements.txt')):
                 echo("-----> Python app detected.", fg='green')
                 deploy_python(app, deltas)


### PR DESCRIPTION
Allows the user to run arbitrary release commands (such as running Django collectstatic and/or migrations). The 'release' command runs before workers are spawned.
Kind of works like this: https://devcenter.heroku.com/articles/release-phase