### PR TITLE
Allow `git push -f` to piku.

### DIFF
--- a/piku.py
+++ b/piku.py
@@ -314,8 +314,8 @@ def do_deploy(app, deltas={}):
     env = {'GIT_WORK_DIR': app_path}
     if exists(app_path):
         echo("-----> Deploying app '{}'".format(app), fg='green')
-        call('git pull --quiet', cwd=app_path, env=env, shell=True)
-        call('git checkout -f', cwd=app_path, env=env, shell=True)
+        call('git fetch --quiet', cwd=app_path, env=env, shell=True)
+        call('git reset --hard origin/master', cwd=app_path, env=env, shell=True)
         if not exists(log_path):
             makedirs(log_path)
         workers = parse_procfile(procfile)


### PR DESCRIPTION
Before this change if you tried to `git push -f paas` it broke the update.
Git would output an error saying branches have diverged.
With this change piku basically assumes whatever you pushed into
origin/master is the thing you actually want to deploy, and uses that.
(even if it's a commit --amend or a reset to some previous point in
history etc.)