### PR TITLE
RFC: letsencrypt SSL certificate support

### DIFF
--- a/piku-bootstrap
+++ b/piku-bootstrap
@@ -178,6 +178,32 @@ main() {
       args:
         creates: ~/.ssh/authorized_keys
 
+    - name: Check if acme.sh is already installed
+      stat:
+        path: ~/.acme.sh/acme.sh
+      register: acme_stat_result
+
+    - name: Download acme.sh
+      get_url:
+        url: https://raw.githubusercontent.com/Neilpang/acme.sh/6ff3f5d/acme.sh
+        dest: ~/acme.sh
+        mode: 0755
+      when: acme_stat_result.stat.exists == False
+      register: acme_installer
+
+    - name: Execute acme.sh installer
+      shell: ./acme.sh --install
+      args:
+        chdir: ~/
+        creates: ~/.acme.sh/acme.sh
+        executable: /bin/bash
+      when: acme_installer is defined
+
+    - name: Remove acme.sh installer
+      file: path=~/acme.sh state=absent
+      when: acme_installer is defined
+
+
 - hosts: all
   become: yes
   tasks:


### PR DESCRIPTION
@rcarmo submitting this for comment and feedback. Sorry about the big diff!

This patch has piku use the `acme.sh` script (when present) to request and maintain Let's Encrypt SSL certs rather than generate self-signed certs. For it to work you must install `acme.sh` as the user piku. Installation instructions for acme.sh are here: https://github.com/Neilpang/acme.sh#1-how-to-install (It's a one-liner as `acme.sh` is pure bash).

The `piku-bootstrap` script has also been updated to install acme.sh for the user automatically, meaning that by default somebody will get SSL on their sites.

If acme.sh is not installed then there is no change in behaviour and piku continues to default to a self-signed certificate.