### PR TITLE
Release worker: provide full env + remove worker.

### DIFF
--- a/piku.py
+++ b/piku.py
@@ -328,6 +328,7 @@ def do_deploy(app, deltas={}):
             settings = parse_settings(config_file, settings)
             if "release" in workers:
                 echo("-----> Releasing", fg='green')
+                settings["ENV_ROOT"] = join(ENV_ROOT, app)
                 retval = call(workers["release"], cwd=app_path, env=settings, shell=True)
                 if retval:
                     exit(retval)


### PR DESCRIPTION
This change improves the `release` task pseudo-worker.

 * Provides the full environment (both app env and config env) to the release task.

 * Uses a non-zero return value to bail early if release phase fails.

 * Adds `ENV_ROOT` (i.e. the location of the virtualenv) to the env available to the release task so that it can run Python code in the right context (same for other languages).