### PR TITLE
Ignore removed workers in SCALING file.

### DIFF
--- a/piku.py
+++ b/piku.py
@@ -632,7 +632,7 @@ def spawn_app(app, deltas={}):
 
     # Configured worker count
     if exists(scaling):
-        worker_count.update({k: int(v) for k,v in parse_procfile(scaling).items()})
+        worker_count.update({k: int(v) for k,v in parse_procfile(scaling).items() if k in workers})
     
     to_create = {}
     to_destroy = {}    


### PR DESCRIPTION
If a worker has been removed from the Procfile it may still have an
entry in the SCALING file on the server which causes a traceback when
the removed worker is attempted to be spawned. With this patch piku
ignores SCALING file entries which do not have a corresponding worker
defined in Procfile.