### PR TITLE
Move release worker to end of deploy.

### DIFF
--- a/examples/python-django/bin/provision-database
+++ b/examples/python-django/bin/provision-database
@@ -1,8 +1,4 @@
 #!/bin/sh
 
-if [ -d "${ENV_ROOT}/bin" ]
-then
-  . ${ENV_ROOT}/bin/activate
-  ./manage.py migrate --no-input
-  ./manage.py collectstatic --no-input
-fi
+./manage.py migrate --no-input
+./manage.py collectstatic --no-input

--- a/piku.py
+++ b/piku.py
@@ -352,13 +352,6 @@ def do_deploy(app, deltas={}):
         if workers and len(workers):
             settings = parse_settings(env_file, env)
             settings = parse_settings(config_file, settings)
-            if "release" in workers:
-                echo("-----> Releasing", fg='green')
-                settings["ENV_ROOT"] = join(ENV_ROOT, app)
-                retval = call(workers["release"], cwd=app_path, env=settings, shell=True)
-                if retval:
-                    exit(retval)
-                workers.pop("release", None)
             if exists(join(app_path, 'requirements.txt')):
                 echo("-----> Python app detected.", fg='green')
                 deploy_python(app, deltas)
@@ -374,6 +367,13 @@ def do_deploy(app, deltas={}):
             else:
                 echo("-----> Could not detect runtime!", fg='red')
             # TODO: detect other runtimes
+            if "release" in workers:
+                echo("-----> Releasing", fg='green')
+                settings.update(environ)
+                retval = call(workers["release"], cwd=app_path, env=settings, shell=True)
+                if retval:
+                    exit(retval)
+                workers.pop("release", None)
         else:
             echo("Error: Invalid Procfile for app '{}'.".format(app), fg='red')
     else:

--- a/piku.py
+++ b/piku.py
@@ -350,26 +350,24 @@ def do_deploy(app, deltas={}):
             makedirs(log_path)
         workers = parse_procfile(procfile)
         if workers and len(workers):
-            settings = parse_settings(env_file, env)
-            settings = parse_settings(config_file, settings)
+            settings = {}
             if exists(join(app_path, 'requirements.txt')):
                 echo("-----> Python app detected.", fg='green')
-                deploy_python(app, deltas)
+                settings.update(deploy_python(app, deltas))
             elif exists(join(app_path, 'package.json')) and check_requirements(['nodejs', 'npm']):
                 echo("-----> Node app detected.", fg='green')
-                deploy_node(app, deltas)
+                settings.update(deploy_node(app, deltas))
             elif exists(join(app_path, 'pom.xml')) and check_requirements(['java', 'mvn']):
                 echo("-----> Java app detected.", fg='green')
-                deploy_java(app, deltas)
+                settings.update(deploy_java(app, deltas))
             elif (exists(join(app_path, 'Godeps')) or len(glob(join(app_path,'*.go')))) and check_requirements(['go']):
                 echo("-----> Go app detected.", fg='green')
-                deploy_go(app, deltas)
+                settings.update(deploy_go(app, deltas))
             else:
                 echo("-----> Could not detect runtime!", fg='red')
             # TODO: detect other runtimes
             if "release" in workers:
                 echo("-----> Releasing", fg='green')
-                settings.update(environ)
                 retval = call(workers["release"], cwd=app_path, env=settings, shell=True)
                 if retval:
                     exit(retval)
@@ -409,7 +407,7 @@ def deploy_go(app, deltas={}):
                 'GO15VENDOREXPERIMENT': '1'
             }
             call('godep update ...', cwd=join(APP_ROOT, app), env=env, shell=True)
-    spawn_app(app, deltas)
+    return spawn_app(app, deltas)
 
 
 def deploy_node(app, deltas={}):
@@ -435,7 +433,7 @@ def deploy_node(app, deltas={}):
             if exists(env_file):
                 env.update(parse_settings(env_file, env))
             call('npm install', cwd=join(APP_ROOT, app), env=env, shell=True)
-    spawn_app(app, deltas)
+    return spawn_app(app, deltas)
 
 
 def deploy_python(app, deltas={}):
@@ -466,7 +464,7 @@ def deploy_python(app, deltas={}):
     if first_time or getmtime(requirements) > getmtime(virtualenv_path):
         echo("-----> Running pip for '{}'".format(app), fg='green')
         call('pip install -r {}'.format(requirements), cwd=virtualenv_path, shell=True)
-    spawn_app(app, deltas)
+    return spawn_app(app, deltas)
 
  
 def spawn_app(app, deltas={}):
@@ -672,6 +670,8 @@ def spawn_app(app, deltas={}):
             if exists(enabled):
                 echo("-----> terminating '{app:s}:{k:s}.{w:d}'".format(**locals()), fg='yellow')
                 unlink(enabled)
+
+    return env
     
 
 def spawn_worker(app, kind, command, env, ordinal=1):


### PR DESCRIPTION
This matches up with what other PaaS platforms do. This change also
makes the release worker inherit the environment (virtualenv etc.) from
the deploy process, making it easier to run e.g. Django manage.py
commands in the expected context without explicitly entering virtualenv
in the script.

Also fixed the Django example now that entering venv is not required.