### PR TITLE
Helper for running piku.py on configured remote.

### DIFF
--- a/piku
+++ b/piku
@@ -1,0 +1,35 @@
+#!/bin/sh
+
+# TODO: support config locations:
+# ./.piku-server
+# ~/.piku-server
+# git config --get remote.piku.url
+# git config --get remote.paas.url
+
+remote=`git config --get remote.piku.url`
+
+echo "Piku remote operator."
+
+if [ "$remote" = "" ]
+then
+  echo
+  echo "Error: no piku server configured."
+  echo "Use PIKU_SERVER=piku@MYSERVER.NET or configure a git remote called 'piku'."
+  echo
+else
+  server=${PIKU_SERVER:-`echo $remote | cut -f1 -d":" 2>/dev/null`}
+  app=${PIKU_APP:-`echo $remote | cut -f2 -d":" 2>/dev/null`}
+  cmd="$1"
+  echo "Server: $server"
+  echo "App: $app"
+  echo
+  case "$cmd" in
+    apps|setup|setup:ssh|"")
+      ssh -A "$server" "$@"
+      ;;
+    *)
+      shift # remove cmd arg
+      ssh -A "$server" "$cmd" "$app" "$@"
+      ;;
+  esac
+fi


### PR DESCRIPTION
This patch adds a little shell script called `piku`.

What it does is check for a git remote called `piku` and then uses that
remote to infer server & app name and SSH in to run piku.py.

Put it on your path and then from any piku configured local repo you can
do things like: `piku restart` and `piku destroy`.

### Examples

I ran the following from my local repo `nodeexample` which has a `piku` remote configured.

Show help:

```
$ piku
Piku remote operator.
Server: piku@piku.mccormickit.com
App: nodeexample

Usage: piku.py [OPTIONS] COMMAND [ARGS]...

  The smallest PaaS you've ever seen

Options:
  --help  Show this message and exit.
...
```

List apps:

```
$ piku apps
Piku remote operator.
Server: piku@piku.mccormickit.com
App: nodeexample

djangoexample
nodeexample
wispexample
```

Run a command:

```
$ piku run env
Piku remote operator.
Server: piku@piku.mccormickit.com
App: nodeexample

MAIL=/var/mail/piku
USER=piku
SSH_CLIENT=202.89.169.99 56928 22
NGINX_SOCKET=127.0.0.1:51355
BIND_ADDRESS=127.0.0.1
...
```