### PR TITLE
If nginx config test fails remove app nginx conf.

### DIFF
--- a/piku.py
+++ b/piku.py
@@ -636,6 +636,15 @@ def spawn_app(app, deltas={}):
                 buffer = expandvars(NGINX_TEMPLATE, env)
             with open(nginx_conf, "w") as h:
                 h.write(buffer)
+            # prevent broken config from breaking other deploys
+            try:
+                nginx_config_test = str(check_output("nginx -t 2>&1 | grep {}".format(app), env=environ, shell=True))
+            except:
+                nginx_config_test = None
+            if nginx_config_test:
+                echo("Error: [nginx config] {}".format(nginx_config_test), fg='red')
+                echo("Warning: removing broken nginx config.", fg='yellow')
+                unlink(nginx_conf)
 
     # Configured worker count
     if exists(scaling):


### PR DESCRIPTION
When deploying multiple apps to the same piku instance it can sometimes happen that an nginx conf is botched because of e.g. something the user put in `NGINX_STATIC_PATHS`. If that happens the user may not realise and when they try to push changes to a different app nginx will fail to restart because the config from the first app is broken.

This change:

 * Shows the user the error in their app's nginx conf so they can fix it.
 * Deletes the broken nginx config so it doesn't prevent other apps from restarting.
