### PR TITLE
Remove --pi hack from bootstrap in favour of pi@raspberry.local

### DIFF
--- a/piku-bootstrap
+++ b/piku-bootstrap
@@ -41,34 +41,36 @@ main() {
   if [ "$1" = "" ]
   then
     echo
-    echo "Usage: `basename $0` HOST [--pi] [...YOUR_ANSIBLE_ARGS...]"
+    echo "Usage: `basename $0` [USER@]HOST [ANSIBLE_ARGS...]"
     echo
     echo " HOST\tCreates a user 'piku' on the machine 'HOST',"
-    echo "\tinstalls git, and install the piku script there."
+    echo "\tinstalls git, and sets up the piku.py script."
     echo
-    echo " --pi\tShortcut to SSH in as the user 'pi'."
-    echo "\tUse \`ssh-copy-id pi@HOSTNAME\` to upload SSH key first."
+    echo " USER\tOptional non-root user to log in as (e.g. 'pi')."
     echo
-    echo "\tRequires root/sudo on HOSTNAME (--pi implies sudo)."
-    echo "\tRequires HOSTNAME to be a Debian based distribution."
+    echo "WARNING: This script installs software and makes changes"
+    echo "         on the target server. Only use a freshly provisioned"
+    echo "         server which you do not mind being modified."
+    echo
+    echo "Notes:"
+    echo
+    echo " * This script requires that you have root/sudo on HOST."
+    echo " * Use \`ssh-copy-id USER@HOST\` to upload your SSH key first."
+    echo " * HOST must be a Debian/Ubuntu based distribution."
+    echo
+    echo "Raspberry Pi example:"
+    echo
+    echo "\t`basename $0` pi@raspberrypi.local"
     echo
   else
     host="$1"; shift
-    # check for raspberry pi user flag
-    if [ "$1" = "--pi" ]; then PIKU_SSH=pi; shift; else PIKU_SSH=root; fi;
     echo "Bootstrapping piku onto ${host}"
-    # TODO: use pyenv + virtualenv on remote instead and install exact versions
-    PIKU_SSH="${PIKU_SSH}" PYTHONWARNINGS="ignore" ansible-playbook -i "${host}", "$@" /dev/stdin << EOF
+    PYTHONWARNINGS="ignore" ansible-playbook -i "${host}", "$@" /dev/stdin << EOF
 ---
 - hosts: all
   become: yes
   gather_facts: no
-  vars:
-    default_user: "{{ lookup('env', 'PIKU_SSH') }}"
   pre_tasks:
-    - name: Set default SSH user
-      set_fact: ansible_ssh_user="{{default_user}}"
-
     - name: Install python2 required by Ansible
       raw: "( /usr/bin/python --version 2>&1 | grep -c 'Python' > /dev/null ) || apt-get update && apt-get -y install python"
 


### PR DESCRIPTION
This patch removes a bunch of uneccessary code as I discovered that ansible will accept a HOST like USER@HOST and so installing like this: `piku-bootstrap pi@raspberrpi.local` works fine. Updated the usage documentation.

I also tested this on Raspbian Buster and it went through with no problems.