### PR TITLE
improvement: allow newlines in ENV files

### DIFF
--- a/examples/python/ENV
+++ b/examples/python/ENV
@@ -1,6 +1,13 @@
+# variables are global and can be replaced
 SETTING1=True
 SETTING2=${SETTING1}/Maybe
+
+# addr:port
 PORT=9080
 BIND_ADDRESS=0.0.0.0
+
+# the max number the worker will process
 RANGE=10
+
+# worker sleep interval between prints
 INTERVAL=1

--- a/piku.py
+++ b/piku.py
@@ -307,7 +307,7 @@ def parse_settings(filename, env={}):
         
     with open(filename, 'r') as settings:
         for line in settings:
-            if '#' == line[0]: # allow for comments
+            if '#' == line[0] or len(line.strip()) == 0: # ignore comments and newlines
                 continue
             try:
                 k, v = map(lambda x: x.strip(), line.split("=", 1))


### PR DESCRIPTION
This will allow ENV to have newlines which will be ignored but will allow for better readability of the ENV file.  Modified the ENV file for one of the examples for example.