### PR TITLE
Env UWSGI_INCLUDE_FILE to include custom uwsgi.

### DIFF
--- a/docs/ENV.md
+++ b/docs/ENV.md
@@ -29,6 +29,7 @@ You can configure deployment settings by placing special variables in an `ENV` f
 * `UWSGI_LOG_X_FORWARDED_FOR` (boolean): set the `log-x-forwarded-for` option.
 * `UWSGI_GEVENT`: enable the Python 2 `gevent` plugin
 * `UWSGI_ASYNCIO`: enable the Python 2/3 `asyncio` plugin
+* `UWSGI_INCLUDE_FILE`: a uwsgi config file in the app's dir to include - useful for including custom uwsgi directives.
 
 ## Nginx Settings
 

--- a/piku.py
+++ b/piku.py
@@ -858,7 +858,10 @@ def spawn_worker(app, kind, command, env, ordinal=1):
     for k in ['NGINX_ACL']:
         if k in env:
             del env[k]
-    
+
+    # insert user defined uwsgi settings if set
+    settings += parse_settings(join(APP_ROOT, app, env.get("UWSGI_INCLUDE_FILE"))).items() if env.get("UWSGI_INCLUDE_FILE") else []
+
     for k, v in env.items():
         settings.append(('env', '{k:s}={v}'.format(**locals())))
 


### PR DESCRIPTION
This PR allows the user to inject custom uwsgi directives into their app's uwsgi config.

Example:

 * In `ENV` set `UWSGI_INCLUDE_FILE=uwsgi.conf`
 * In the app dir create a file called `uwsgi.conf`
 * Add a directive such as `manage-script-name = true`

Then the value `manage-script-name` will be added to the uwsgi config for the app.